### PR TITLE
Add WithLongRunningSteps option for handlers that run for extended periods

### DIFF
--- a/docs/ENGINE_SPEC.md
+++ b/docs/ENGINE_SPEC.md
@@ -579,7 +579,22 @@ engine := NewEngine(pool,
 
 This ensures low-priority steps eventually get processed even in busy queues.
 
-### 6.4 Workflow Events
+### 6.4 Long-Running Steps Mode
+
+For handlers that run for extended periods (minutes to hours), enable long-running mode:
+
+```go
+engine := NewEngine(pool, WithLongRunningSteps())
+```
+
+In this mode, handler execution happens outside of the database transaction. This releases the DB connection during handler execution and makes the "running" status immediately visible.
+
+**Trade-offs:**
+
+- If a worker crashes mid-handler, the step remains in "running" status — implement a recovery mechanism to reset stuck steps
+- Handlers should be idempotent or use `StepContext.IdempotencyKey()`
+
+### 6.5 Workflow Events
 
 All state changes are persisted as events.
 

--- a/engine.go
+++ b/engine.go
@@ -50,6 +50,9 @@ type Engine struct {
 	missingHandlerJitterPct   float64
 	skipLogMu                 sync.Mutex
 	skipLogNextAllowed        map[string]time.Time
+
+	// Long-running steps mode: execute handlers outside of transaction
+	longRunningSteps bool
 }
 
 // StartAwaitResult contains the result of StartAwait operation.
@@ -320,6 +323,11 @@ func (engine *Engine) ExecuteNext(ctx context.Context, workerID string) (empty b
 		return true, nil
 	}
 
+	// Use long-running mode if enabled
+	if engine.longRunningSteps {
+		return engine.executeNextLongRunning(ctx, workerID)
+	}
+
 	err = engine.txManager.ReadCommitted(ctx, func(ctx context.Context) error {
 		if engine.isShutdown() {
 			empty = true
@@ -499,6 +507,286 @@ func (engine *Engine) ExecuteNext(ctx context.Context, workerID string) (empty b
 	}
 
 	return empty, nil
+}
+
+// longRunningStepContext holds the data needed to execute a step across multiple transactions.
+type longRunningStepContext struct {
+	item     *QueueItem
+	instance *WorkflowInstance
+	step     *WorkflowStep
+	stepDef  *StepDefinition
+	def      *WorkflowDefinition
+}
+
+// executeNextLongRunning executes the next step with handler running outside of transaction.
+// This mode is optimized for handlers that run for extended periods (minutes to hours).
+func (engine *Engine) executeNextLongRunning(ctx context.Context, workerID string) (empty bool, err error) {
+	var execCtx *longRunningStepContext
+	var skipStep bool
+	var useNormalExecution bool
+
+	// Transaction 1: Dequeue, validate, and prepare step for execution
+	err = engine.txManager.ReadCommitted(ctx, func(txCtx context.Context) error {
+		if engine.isShutdown() {
+			empty = true
+			return nil
+		}
+
+		item, err := engine.store.DequeueStep(txCtx, workerID)
+		if err != nil {
+			return fmt.Errorf("dequeue step: %w", err)
+		}
+
+		if item == nil {
+			empty = true
+			return nil
+		}
+
+		if engine.isShutdown() {
+			_ = engine.store.ReleaseQueueItem(txCtx, item.ID)
+			empty = true
+			return nil
+		}
+
+		instance, err := engine.store.GetInstance(txCtx, item.InstanceID)
+		if err != nil {
+			return fmt.Errorf("get instance: %w", err)
+		}
+
+		// If workflow is in DLQ state, skip execution
+		if instance.Status == StatusDLQ {
+			_ = engine.store.LogEvent(txCtx, instance.ID, nil, EventStepFailed, map[string]any{
+				KeyMessage: "instance in DLQ state, skipping queued item",
+			})
+			_ = engine.store.RemoveFromQueue(txCtx, item.ID)
+			skipStep = true
+			return nil
+		}
+
+		var step *WorkflowStep
+		if item.StepID == nil {
+			step, err = engine.createFirstStep(txCtx, instance)
+			if err != nil {
+				return fmt.Errorf("create first step: %w", err)
+			}
+		} else {
+			steps, err := engine.store.GetStepsByInstance(txCtx, instance.ID)
+			if err != nil {
+				return fmt.Errorf("get steps: %w", err)
+			}
+
+			for _, currStep := range steps {
+				currStep := currStep
+				if currStep.ID == *item.StepID {
+					step = &currStep
+					break
+				}
+			}
+
+			if step == nil {
+				return fmt.Errorf("step not found: %d", *item.StepID)
+			}
+		}
+
+		// Do not execute skipped or paused steps
+		if step.Status == StepStatusSkipped ||
+			step.Status == StepStatusPaused ||
+			step.Status == StepStatusRolledBack {
+			_ = engine.store.RemoveFromQueue(txCtx, step.ID)
+			skipStep = true
+			return nil
+		}
+
+		def, err := engine.store.GetWorkflowDefinition(txCtx, instance.WorkflowID)
+		if err != nil {
+			return fmt.Errorf("get workflow definition: %w", err)
+		}
+
+		stepDef, ok := def.Definition.Steps[step.StepName]
+		if !ok {
+			return fmt.Errorf("step definition not found: %s", step.StepName)
+		}
+
+		// Check if this is a compensation step
+		if step.Status == StepStatusCompensation {
+			if stepDef.OnFailure != "" {
+				if onFailDef, ok := def.Definition.Steps[stepDef.OnFailure]; ok {
+					engine.mu.RLock()
+					_, has := engine.handlers[onFailDef.Handler]
+					engine.mu.RUnlock()
+					if !has {
+						// No local handler, reschedule
+						delay := engine.jitteredCooldown()
+						if delay > 0 {
+							_ = engine.store.RescheduleAndReleaseQueueItem(txCtx, item.ID, delay)
+						} else {
+							_ = engine.store.ReleaseQueueItem(txCtx, item.ID)
+						}
+						logKey := fmt.Sprintf("comp-skip:%d:%s", instance.ID, step.StepName)
+						if engine.shouldLogSkip(logKey) {
+							_ = engine.store.LogEvent(txCtx, instance.ID, nil, EventStepSkippedMissingHandler, map[string]any{
+								KeyStepName: step.StepName,
+								KeyMessage:  "no local compensation handler registered; rescheduled",
+							})
+						}
+						skipStep = true
+						return nil
+					}
+				}
+			}
+			// Compensation steps use normal execution (within transaction)
+			useNormalExecution = true
+		}
+
+		// Check for missing handlers on task steps
+		if step.StepType == StepTypeTask && !useNormalExecution {
+			engine.mu.RLock()
+			_, has := engine.handlers[stepDef.Handler]
+			engine.mu.RUnlock()
+			if !has {
+				delay := engine.jitteredCooldown()
+				if delay > 0 {
+					_ = engine.store.RescheduleAndReleaseQueueItem(txCtx, item.ID, delay)
+				} else {
+					_ = engine.store.ReleaseQueueItem(txCtx, item.ID)
+				}
+				logKey := fmt.Sprintf("task-skip:%d:%s", instance.ID, step.StepName)
+				if engine.shouldLogSkip(logKey) {
+					_ = engine.store.LogEvent(txCtx, instance.ID, nil, EventStepSkippedMissingHandler, map[string]any{
+						KeyStepName: step.StepName,
+						KeyMessage:  "no local handler registered; rescheduled",
+					})
+				}
+				skipStep = true
+				return nil
+			}
+		}
+
+		// For non-Task steps (Fork, Join, Condition, SavePoint, Human), use normal execution
+		if step.StepType != StepTypeTask {
+			useNormalExecution = true
+		}
+
+		// If using normal execution, do it within this transaction
+		if useNormalExecution {
+			engine.activeSteps.Add(1)
+			defer engine.activeSteps.Done()
+			defer func() {
+				_ = engine.store.RemoveFromQueue(txCtx, item.ID)
+			}()
+
+			if step.Status == StepStatusCompensation {
+				return engine.executeCompensationStep(txCtx, instance, step)
+			}
+			return engine.executeStep(txCtx, instance, step)
+		}
+
+		// For Task steps in long-running mode:
+		// Update status to running and remove from queue within this transaction
+		if err := engine.store.UpdateStep(txCtx, step.ID, StepStatusRunning, nil, nil); err != nil {
+			return fmt.Errorf("update step status: %w", err)
+		}
+
+		_ = engine.store.LogEvent(txCtx, instance.ID, &step.ID, EventStepStarted, map[string]any{
+			KeyStepName: step.StepName,
+			KeyStepType: stepDef.Type,
+		})
+
+		_ = engine.store.RemoveFromQueue(txCtx, item.ID)
+
+		// Save context for handler execution outside transaction
+		execCtx = &longRunningStepContext{
+			item:     item,
+			instance: instance,
+			step:     step,
+			stepDef:  stepDef,
+			def:      def,
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return empty, err
+	}
+
+	if empty || skipStep || useNormalExecution || execCtx == nil {
+		return empty, nil
+	}
+
+	// Track active step for graceful shutdown
+	engine.activeSteps.Add(1)
+	defer engine.activeSteps.Done()
+
+	// Execute handler OUTSIDE of transaction
+	// This is the key difference - the DB connection is released during handler execution
+	handlerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	engine.registerInstanceContext(execCtx.instance.ID, execCtx.step.ID, cancel)
+	defer engine.unregisterInstanceContext(execCtx.instance.ID, execCtx.step.ID)
+
+	// Check for cancellation before starting handler
+	cancelReq, err := engine.store.GetCancelRequest(ctx, execCtx.instance.ID)
+	if err == nil && cancelReq != nil {
+		// Handle cancellation in a new transaction
+		return false, engine.txManager.ReadCommitted(ctx, func(txCtx context.Context) error {
+			return engine.handleCancellation(txCtx, execCtx.instance, execCtx.step, cancelReq)
+		})
+	}
+
+	// Apply timeout if configured
+	if execCtx.stepDef.Timeout != 0 {
+		var timeoutCancel context.CancelFunc
+		handlerCtx, timeoutCancel = context.WithTimeout(handlerCtx, execCtx.stepDef.Timeout)
+		defer timeoutCancel()
+	}
+
+	// PLUGIN HOOK: OnStepStart
+	if engine.pluginManager != nil {
+		if err := engine.pluginManager.ExecuteStepStart(ctx, execCtx.instance, execCtx.step); err != nil {
+			return false, engine.txManager.ReadCommitted(ctx, func(txCtx context.Context) error {
+				return engine.handleStepFailure(txCtx, execCtx.instance, execCtx.step, execCtx.stepDef, err)
+			})
+		}
+	}
+
+	// Execute the handler (this can take minutes/hours)
+	output, stepErr := engine.executeTask(handlerCtx, execCtx.instance, execCtx.step, execCtx.stepDef)
+
+	// Check for cancellation after handler completes
+	if errors.Is(handlerCtx.Err(), context.Canceled) {
+		cancelReq, err = engine.store.GetCancelRequest(ctx, execCtx.instance.ID)
+		if err == nil && cancelReq != nil {
+			return false, engine.txManager.ReadCommitted(ctx, func(txCtx context.Context) error {
+				return engine.handleCancellation(txCtx, execCtx.instance, execCtx.step, cancelReq)
+			})
+		}
+	}
+
+	// Transaction 2: Handle step result (success or failure)
+	err = engine.txManager.ReadCommitted(ctx, func(txCtx context.Context) error {
+		if stepErr != nil {
+			// PLUGIN HOOK: OnStepFailed
+			if engine.pluginManager != nil {
+				if errPlugin := engine.pluginManager.ExecuteStepFailed(txCtx, execCtx.instance, execCtx.step, stepErr); errPlugin != nil {
+					slog.Warn("[floxy] plugin hook OnStepFailed failed", "error", errPlugin)
+				}
+			}
+			return engine.handleStepFailure(txCtx, execCtx.instance, execCtx.step, execCtx.stepDef, stepErr)
+		}
+
+		// PLUGIN HOOK: OnStepComplete
+		if engine.pluginManager != nil {
+			if err := engine.pluginManager.ExecuteStepComplete(txCtx, execCtx.instance, execCtx.step); err != nil {
+				slog.Warn("[floxy] plugin hook OnStepComplete failed", "error", err)
+			}
+		}
+
+		return engine.handleStepSuccess(txCtx, execCtx.instance, execCtx.step, execCtx.stepDef, output, true)
+	})
+
+	return false, err
 }
 
 func (engine *Engine) MakeHumanDecision(

--- a/engine_long_running_test.go
+++ b/engine_long_running_test.go
@@ -1,0 +1,409 @@
+package floxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestWithLongRunningSteps(t *testing.T) {
+	mockTxManager := NewMockTxManager(t)
+	mockStore := NewMockStore(t)
+	mockStore.EXPECT().GetCancelRequest(mock.Anything, mock.Anything).Return(nil, ErrEntityNotFound).Maybe()
+
+	engine := NewEngine(nil,
+		WithEngineTxManager(mockTxManager),
+		WithEngineStore(mockStore),
+		WithLongRunningSteps(),
+	)
+	defer engine.Shutdown()
+
+	assert.True(t, engine.longRunningSteps)
+}
+
+func TestEngine_ExecuteNext_LongRunning_EmptyQueue(t *testing.T) {
+	mockTxManager := NewMockTxManager(t)
+	mockStore := NewMockStore(t)
+	mockStore.EXPECT().GetCancelRequest(mock.Anything, mock.Anything).Return(nil, ErrEntityNotFound).Maybe()
+
+	engine := NewEngine(nil,
+		WithEngineTxManager(mockTxManager),
+		WithEngineStore(mockStore),
+		WithLongRunningSteps(),
+	)
+	defer engine.Shutdown()
+
+	mockTxManager.EXPECT().ReadCommitted(mock.Anything, mock.Anything).Run(func(ctx context.Context, fn func(ctx context.Context) error) {
+		fn(ctx)
+	}).Return(nil)
+
+	mockStore.EXPECT().DequeueStep(mock.Anything, "worker1").Return(nil, nil)
+
+	empty, err := engine.ExecuteNext(context.Background(), "worker1")
+
+	assert.NoError(t, err)
+	assert.True(t, empty)
+}
+
+func TestEngine_ExecuteNext_LongRunning_TaskStep_Success(t *testing.T) {
+	mockTxManager := NewMockTxManager(t)
+	mockStore := NewMockStore(t)
+	mockStore.EXPECT().GetCancelRequest(mock.Anything, mock.Anything).Return(nil, ErrEntityNotFound).Maybe()
+
+	engine := NewEngine(nil,
+		WithEngineTxManager(mockTxManager),
+		WithEngineStore(mockStore),
+		WithLongRunningSteps(),
+	)
+	defer engine.Shutdown()
+
+	// Register a handler
+	handlerCalled := atomic.Bool{}
+	mockHandler := NewMockStepHandler(t)
+	mockHandler.EXPECT().Name().Return("test-handler")
+	mockHandler.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, stepCtx StepContext, input json.RawMessage) {
+		handlerCalled.Store(true)
+	}).Return(json.RawMessage(`{"result": "success"}`), nil)
+	engine.RegisterHandler(mockHandler)
+
+	workflowID := "test-workflow"
+	stepID := int64(1)
+	instanceID := int64(123)
+
+	definition := &WorkflowDefinition{
+		ID:   workflowID,
+		Name: "Test Workflow",
+		Definition: GraphDefinition{
+			Start: "step1",
+			Steps: map[string]*StepDefinition{
+				"step1": {
+					Name:       "step1",
+					Type:       StepTypeTask,
+					Handler:    "test-handler",
+					MaxRetries: 3,
+				},
+			},
+		},
+	}
+
+	instance := &WorkflowInstance{
+		ID:         instanceID,
+		WorkflowID: workflowID,
+		Status:     StatusRunning,
+	}
+
+	step := &WorkflowStep{
+		ID:         stepID,
+		InstanceID: instanceID,
+		StepName:   "step1",
+		StepType:   StepTypeTask,
+		Status:     StepStatusPending,
+		Input:      json.RawMessage(`{"test": "input"}`),
+	}
+
+	queueItem := &QueueItem{
+		ID:         1,
+		InstanceID: instanceID,
+		StepID:     &stepID,
+	}
+
+	// Transaction 1: Dequeue and prepare
+	txCallCount := 0
+	mockTxManager.EXPECT().ReadCommitted(mock.Anything, mock.Anything).Run(func(ctx context.Context, fn func(ctx context.Context) error) {
+		txCallCount++
+		fn(ctx)
+	}).Return(nil).Times(2) // Called twice: once for prepare, once for finalize
+
+	mockStore.EXPECT().DequeueStep(mock.Anything, "worker1").Return(queueItem, nil).Once()
+	mockStore.EXPECT().GetInstance(mock.Anything, instanceID).Return(instance, nil).Maybe()
+	mockStore.EXPECT().GetStepsByInstance(mock.Anything, instanceID).Return([]WorkflowStep{*step}, nil).Maybe()
+	mockStore.EXPECT().GetWorkflowDefinition(mock.Anything, workflowID).Return(definition, nil).Maybe()
+	mockStore.EXPECT().UpdateStep(mock.Anything, stepID, StepStatusRunning, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().LogEvent(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().RemoveFromQueue(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Transaction 2: Handle success
+	mockStore.EXPECT().UpdateStep(mock.Anything, stepID, StepStatusCompleted, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().UpdateInstanceStatus(mock.Anything, instanceID, StatusCompleted, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	empty, err := engine.ExecuteNext(context.Background(), "worker1")
+
+	assert.NoError(t, err)
+	assert.False(t, empty)
+	assert.True(t, handlerCalled.Load(), "Handler should have been called")
+	assert.Equal(t, 2, txCallCount, "Should have two transactions")
+}
+
+func TestEngine_ExecuteNext_LongRunning_TaskStep_HandlerError(t *testing.T) {
+	mockTxManager := NewMockTxManager(t)
+	mockStore := NewMockStore(t)
+	mockStore.EXPECT().GetCancelRequest(mock.Anything, mock.Anything).Return(nil, ErrEntityNotFound).Maybe()
+
+	engine := NewEngine(nil,
+		WithEngineTxManager(mockTxManager),
+		WithEngineStore(mockStore),
+		WithLongRunningSteps(),
+	)
+	defer engine.Shutdown()
+
+	// Register a handler that fails
+	mockHandler := NewMockStepHandler(t)
+	mockHandler.EXPECT().Name().Return("test-handler")
+	mockHandler.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("handler failed"))
+	engine.RegisterHandler(mockHandler)
+
+	workflowID := "test-workflow"
+	stepID := int64(1)
+	instanceID := int64(123)
+
+	definition := &WorkflowDefinition{
+		ID:   workflowID,
+		Name: "Test Workflow",
+		Definition: GraphDefinition{
+			Start: "step1",
+			Steps: map[string]*StepDefinition{
+				"step1": {
+					Name:       "step1",
+					Type:       StepTypeTask,
+					Handler:    "test-handler",
+					MaxRetries: 0, // No retries at all
+				},
+			},
+		},
+	}
+
+	instance := &WorkflowInstance{
+		ID:         instanceID,
+		WorkflowID: workflowID,
+		Status:     StatusRunning,
+	}
+
+	step := &WorkflowStep{
+		ID:         stepID,
+		InstanceID: instanceID,
+		StepName:   "step1",
+		StepType:   StepTypeTask,
+		Status:     StepStatusPending,
+		MaxRetries: 0,
+		Input:      json.RawMessage(`{"test": "input"}`),
+	}
+
+	queueItem := &QueueItem{
+		ID:         1,
+		InstanceID: instanceID,
+		StepID:     &stepID,
+	}
+
+	mockTxManager.EXPECT().ReadCommitted(mock.Anything, mock.Anything).Run(func(ctx context.Context, fn func(ctx context.Context) error) {
+		fn(ctx)
+	}).Return(nil).Times(2)
+
+	// All store calls - use Maybe() for flexibility
+	mockStore.EXPECT().DequeueStep(mock.Anything, "worker1").Return(queueItem, nil).Once()
+	mockStore.EXPECT().GetInstance(mock.Anything, instanceID).Return(instance, nil).Maybe()
+	mockStore.EXPECT().GetStepsByInstance(mock.Anything, instanceID).Return([]WorkflowStep{*step}, nil).Maybe()
+	mockStore.EXPECT().GetWorkflowDefinition(mock.Anything, workflowID).Return(definition, nil).Maybe()
+	mockStore.EXPECT().UpdateStep(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().LogEvent(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().RemoveFromQueue(mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().UpdateInstanceStatus(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().EnqueueStep(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	empty, err := engine.ExecuteNext(context.Background(), "worker1")
+
+	assert.NoError(t, err)
+	assert.False(t, empty)
+}
+
+func TestEngine_ExecuteNext_LongRunning_NonTaskStep_UsesNormalExecution(t *testing.T) {
+	mockTxManager := NewMockTxManager(t)
+	mockStore := NewMockStore(t)
+	mockStore.EXPECT().GetCancelRequest(mock.Anything, mock.Anything).Return(nil, ErrEntityNotFound).Maybe()
+
+	engine := NewEngine(nil,
+		WithEngineTxManager(mockTxManager),
+		WithEngineStore(mockStore),
+		WithLongRunningSteps(),
+	)
+	defer engine.Shutdown()
+
+	workflowID := "test-workflow"
+	stepID := int64(1)
+	instanceID := int64(123)
+
+	definition := &WorkflowDefinition{
+		ID:   workflowID,
+		Name: "Test Workflow",
+		Definition: GraphDefinition{
+			Start: "savepoint1",
+			Steps: map[string]*StepDefinition{
+				"savepoint1": {
+					Name: "savepoint1",
+					Type: StepTypeSavePoint,
+				},
+			},
+		},
+	}
+
+	instance := &WorkflowInstance{
+		ID:         instanceID,
+		WorkflowID: workflowID,
+		Status:     StatusRunning,
+	}
+
+	step := &WorkflowStep{
+		ID:         stepID,
+		InstanceID: instanceID,
+		StepName:   "savepoint1",
+		StepType:   StepTypeSavePoint,
+		Status:     StepStatusPending,
+		Input:      json.RawMessage(`{}`),
+	}
+
+	queueItem := &QueueItem{
+		ID:         1,
+		InstanceID: instanceID,
+		StepID:     &stepID,
+	}
+
+	// For non-Task steps, only one transaction should be used (normal execution)
+	txCallCount := 0
+	mockTxManager.EXPECT().ReadCommitted(mock.Anything, mock.Anything).Run(func(ctx context.Context, fn func(ctx context.Context) error) {
+		txCallCount++
+		fn(ctx)
+	}).Return(nil).Once()
+
+	mockStore.EXPECT().DequeueStep(mock.Anything, "worker1").Return(queueItem, nil).Once()
+	mockStore.EXPECT().GetInstance(mock.Anything, instanceID).Return(instance, nil).Maybe()
+	mockStore.EXPECT().GetStepsByInstance(mock.Anything, instanceID).Return([]WorkflowStep{*step}, nil).Maybe()
+	mockStore.EXPECT().GetWorkflowDefinition(mock.Anything, workflowID).Return(definition, nil).Maybe()
+	mockStore.EXPECT().RemoveFromQueue(mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().UpdateStep(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().LogEvent(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().UpdateInstanceStatus(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	empty, err := engine.ExecuteNext(context.Background(), "worker1")
+
+	assert.NoError(t, err)
+	assert.False(t, empty)
+	assert.Equal(t, 1, txCallCount, "Non-task steps should use single transaction (normal execution)")
+}
+
+func TestEngine_ExecuteNext_LongRunning_MissingHandler_Rescheduled(t *testing.T) {
+	mockTxManager := NewMockTxManager(t)
+	mockStore := NewMockStore(t)
+	mockStore.EXPECT().GetCancelRequest(mock.Anything, mock.Anything).Return(nil, ErrEntityNotFound).Maybe()
+
+	engine := NewEngine(nil,
+		WithEngineTxManager(mockTxManager),
+		WithEngineStore(mockStore),
+		WithLongRunningSteps(),
+		WithMissingHandlerCooldown(time.Second),
+	)
+	defer engine.Shutdown()
+
+	// No handler registered
+
+	workflowID := "test-workflow"
+	stepID := int64(1)
+	instanceID := int64(123)
+
+	definition := &WorkflowDefinition{
+		ID:   workflowID,
+		Name: "Test Workflow",
+		Definition: GraphDefinition{
+			Start: "step1",
+			Steps: map[string]*StepDefinition{
+				"step1": {
+					Name:    "step1",
+					Type:    StepTypeTask,
+					Handler: "missing-handler",
+				},
+			},
+		},
+	}
+
+	instance := &WorkflowInstance{
+		ID:         instanceID,
+		WorkflowID: workflowID,
+		Status:     StatusRunning,
+	}
+
+	step := &WorkflowStep{
+		ID:         stepID,
+		InstanceID: instanceID,
+		StepName:   "step1",
+		StepType:   StepTypeTask,
+		Status:     StepStatusPending,
+	}
+
+	queueItem := &QueueItem{
+		ID:         1,
+		InstanceID: instanceID,
+		StepID:     &stepID,
+	}
+
+	mockTxManager.EXPECT().ReadCommitted(mock.Anything, mock.Anything).Run(func(ctx context.Context, fn func(ctx context.Context) error) {
+		fn(ctx)
+	}).Return(nil).Once()
+
+	mockStore.EXPECT().DequeueStep(mock.Anything, "worker1").Return(queueItem, nil).Once()
+	mockStore.EXPECT().GetInstance(mock.Anything, instanceID).Return(instance, nil).Once()
+	mockStore.EXPECT().GetStepsByInstance(mock.Anything, instanceID).Return([]WorkflowStep{*step}, nil).Once()
+	mockStore.EXPECT().GetWorkflowDefinition(mock.Anything, workflowID).Return(definition, nil).Once()
+	mockStore.EXPECT().RescheduleAndReleaseQueueItem(mock.Anything, queueItem.ID, mock.Anything).Return(nil).Once()
+	mockStore.EXPECT().LogEvent(mock.Anything, instanceID, mock.Anything, EventStepSkippedMissingHandler, mock.Anything).Return(nil).Maybe()
+
+	empty, err := engine.ExecuteNext(context.Background(), "worker1")
+
+	assert.NoError(t, err)
+	assert.False(t, empty)
+}
+
+func TestEngine_ExecuteNext_LongRunning_DLQInstance_Skipped(t *testing.T) {
+	mockTxManager := NewMockTxManager(t)
+	mockStore := NewMockStore(t)
+	mockStore.EXPECT().GetCancelRequest(mock.Anything, mock.Anything).Return(nil, ErrEntityNotFound).Maybe()
+
+	engine := NewEngine(nil,
+		WithEngineTxManager(mockTxManager),
+		WithEngineStore(mockStore),
+		WithLongRunningSteps(),
+	)
+	defer engine.Shutdown()
+
+	stepID := int64(1)
+	instanceID := int64(123)
+
+	instance := &WorkflowInstance{
+		ID:         instanceID,
+		WorkflowID: "test-workflow",
+		Status:     StatusDLQ, // Instance in DLQ state
+	}
+
+	queueItem := &QueueItem{
+		ID:         1,
+		InstanceID: instanceID,
+		StepID:     &stepID,
+	}
+
+	mockTxManager.EXPECT().ReadCommitted(mock.Anything, mock.Anything).Run(func(ctx context.Context, fn func(ctx context.Context) error) {
+		fn(ctx)
+	}).Return(nil).Once()
+
+	mockStore.EXPECT().DequeueStep(mock.Anything, "worker1").Return(queueItem, nil).Once()
+	mockStore.EXPECT().GetInstance(mock.Anything, instanceID).Return(instance, nil).Once()
+	mockStore.EXPECT().LogEvent(mock.Anything, instanceID, mock.Anything, EventStepFailed, mock.Anything).Return(nil).Once()
+	mockStore.EXPECT().RemoveFromQueue(mock.Anything, queueItem.ID).Return(nil).Once()
+
+	empty, err := engine.ExecuteNext(context.Background(), "worker1")
+
+	assert.NoError(t, err)
+	assert.False(t, empty)
+}

--- a/engine_opts.go
+++ b/engine_opts.go
@@ -79,3 +79,29 @@ func WithQueueAgingRate(rate float64) EngineOption {
 		e.store.SetAgingRate(rate)
 	}
 }
+
+// WithLongRunningSteps enables a mode optimized for handlers that run for extended periods
+// (minutes to hours). In this mode, the handler execution happens outside of the database
+// transaction, which:
+//
+//   - Releases the database connection during handler execution
+//   - Makes the "running" status immediately visible to other connections
+//   - Prevents connection pool exhaustion with many concurrent workers
+//
+// Trade-offs:
+//
+//   - If a worker crashes during handler execution, the step will be stuck in "running" status.
+//     You should implement a recovery mechanism to reset stuck steps (e.g., a cron job that
+//     resets steps in "running" status for longer than expected execution time).
+//
+//   - Handlers should be idempotent or use the IdempotencyKey from StepContext to handle
+//     potential re-execution after recovery.
+//
+// Example usage:
+//
+//	engine := NewEngine(pool, WithLongRunningSteps())
+func WithLongRunningSteps() EngineOption {
+	return func(e *Engine) {
+		e.longRunningSteps = true
+	}
+}


### PR DESCRIPTION
## Problem

When using Floxy with handlers that take a long time to execute (20-80 minutes), the entire `ExecuteNext` operation runs within a single database transaction. This causes:

1. **Connection pool exhaustion** — each worker holds a DB connection for the entire handler duration
2. **Invisible "running" status** — other connections see `pending` until handler completes (PostgreSQL `READ COMMITTED`)
3. **Scalability issues** — with 200+ workers and long handlers, the connection pool is exhausted

## Solution

Add `WithLongRunningSteps()` engine option that splits step execution into separate transactions:

```go
engine := NewEngine(pool, WithLongRunningSteps())
```

**How it works:**

1. **Transaction 1:** Dequeue step, update status to `running`, remove from queue, commit
   - Status is immediately visible to other connections
   - DB connection is released
2. **Outside transaction:** Execute handler (can take minutes/hours)
3. **Transaction 2:** Record result (success/failure), enqueue next steps

**Scope:**
- Task steps: use split-transaction mode
- Non-Task steps (Fork, Join, Condition, SavePoint, Human): use normal single-transaction (they are fast)
- Compensation steps: use normal execution

## Trade-offs

- If a worker crashes mid-handler, the step remains in `running` status — users should implement a recovery mechanism
- Handlers should be idempotent or use `StepContext.IdempotencyKey()`

## Changes

- `engine_opts.go`: add `WithLongRunningSteps()` option
- `engine.go`: add `executeNextLongRunning()` method and `longRunningStepContext` struct
- `engine_long_running_test.go`: tests for the new mode
- `docs/ENGINE_SPEC.md`: documentation

## Testing

All existing tests pass. Added new tests covering:
- Empty queue handling
- Successful task step execution
- Failed task step with retries exhausted
- Non-task steps using normal execution
- Missing handler rescheduling
- DLQ instance skipping